### PR TITLE
DDL example

### DIFF
--- a/db.go
+++ b/db.go
@@ -116,6 +116,15 @@ func RunMigrations() {
 			}
 			return nil
 		},
+	}, {
+		// alter table
+		ID: "202307101900",
+		Migrate: func(db *gorm.DB) error {
+			if err := db.Exec("ALTER TABLE `users` ADD `wrong_field_name` varchar(255) NOT NULL").Error; err != nil {
+				return err
+			}
+			return nil
+		},
 	}})
 
 	if err = m.Migrate(); err != nil {

--- a/db.go
+++ b/db.go
@@ -120,7 +120,7 @@ func RunMigrations() {
 		// alter table
 		ID: "202307101900",
 		Migrate: func(db *gorm.DB) error {
-			if err := db.Exec("ALTER TABLE `users` ADD `wrong_field_name` varchar(255) NOT NULL").Error; err != nil {
+			if err := db.Exec("ALTER TABLE `users` ADD `new_field` varchar(255) NOT NULL").Error; err != nil {
 				return err
 			}
 			return nil

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver, tidb
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: "jinzhu", NewField: "new_field"}
 
 	DB.Create(&user)
 

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	NewField  string
 }
 
 type Account struct {


### PR DESCRIPTION
This example will add a new field called `new_field` in the user table. The first commit type the `new_field` as `wrong_field_name` and the second commit corrects it.

1. The test in GitHub action will fail in the first commit because of the wrong field name.
![image](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/assets/52435083/c4464549-5788-456e-a5ec-05dc68fdce43)
![image](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/assets/52435083/3becc3d1-efd8-4fd3-990a-6a10ebf5c1e2)

2. The test in GitHub action will succeed in the second commit which we fix the bug.

![image](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/assets/52435083/5e655552-292a-4f5a-b069-71bf99d73b53)


**The wrong DDL in the first commit will not be applied to the production database because we test it in the TiDB Serverless branch.**