### PR TITLE
DDL: add column typo example

### DIFF
--- a/db.go
+++ b/db.go
@@ -120,7 +120,7 @@ func RunMigrations() {
 		// alter table
 		ID: "202307111200",
 		Migrate: func(db *gorm.DB) error {
-			if err := db.Exec("ALTER TABLE `users` ADD `wrong_new_field` varchar(255) NOT NULL").Error; err != nil {
+			if err := db.Exec("ALTER TABLE `users` ADD `new_field` varchar(255) NOT NULL").Error; err != nil {
 				return err
 			}
 			return nil

--- a/db.go
+++ b/db.go
@@ -116,6 +116,15 @@ func RunMigrations() {
 			}
 			return nil
 		},
+	}, {
+		// alter table
+		ID: "202307111200",
+		Migrate: func(db *gorm.DB) error {
+			if err := db.Exec("ALTER TABLE `users` ADD `wrong_new_field` varchar(255) NOT NULL").Error; err != nil {
+				return err
+			}
+			return nil
+		},
 	}})
 
 	if err = m.Migrate(); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver, tidb
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: "jinzhu", NewField: "new_field"}
 
 	DB.Create(&user)
 

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	NewField  string
 }
 
 type Account struct {


### PR DESCRIPTION
# How GitHub App works in this example

This example adds a new field called `new_field` in the user table. The [first commit](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/pull/9/commits/a009baf6f4761a0ab9485de5d7e9ed0128298a92) type the `new_field` as `wrong_new_field` and the [second commit](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/pull/9/commits/0bb748f9e2d1623dff0abe069f4f1887e888c7ae) corrects it.

1. The test in GitHub action will fail in the first commit because of the wrong field name.

![image](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/assets/52435083/e311949b-b06b-47f1-8280-a1c29274f78f)
![image](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/assets/52435083/b702d5d7-4d8b-4f2d-af7d-b8afa385934b)

2. The test in GitHub action will succeed in the second commit which we fix the bug.

![image](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/assets/52435083/5cb0e51b-1ab0-42b8-806d-9bf67e1d7257)

![image](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/assets/52435083/5f0b0b95-6ad2-43c6-bf53-76b814360aa6)

# Summarize

In this example: 
1. The branch helps us find the wrong DDL in the first commit, and it will not be applied to the production database.
2. We can not execute such a test in a new database without branch. Because the `AutoMigrate` always loads the whole fields, causing an error in the new added DDL.