### PR TITLE
DDL: add unique key example

### DIFF
--- a/db.go
+++ b/db.go
@@ -116,7 +116,17 @@ func RunMigrations() {
 			}
 			return nil
 		},
-	}})
+	}, {
+		// alter name column as unique key
+		ID: "202307262210",
+		Migrate: func(db *gorm.DB) error {
+			if err := db.Exec("ALTER TABLE `users` ADD UNIQUE (name(32))").Error; err != nil {
+				return err
+			}
+			return nil
+		},
+	},
+	})
 
 	if err = m.Migrate(); err != nil {
 		log.Fatalf("Migration failed: %v", err)

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/google/uuid"
 	"testing"
 )
 
@@ -9,7 +10,7 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver, tidb
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: uuid.NewString()}
 
 	DB.Create(&user)
 

--- a/main_test.go
+++ b/main_test.go
@@ -19,3 +19,20 @@ func TestGORM(t *testing.T) {
 		t.Errorf("Failed, got error: %v", err)
 	}
 }
+
+func TestUniqueKey(t *testing.T) {
+
+	name := uuid.NewString()
+	user := User{Name: name}
+	if err := DB.Create(&user).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+	if err := DB.Create(&user).Error; err == nil {
+		t.Error("Should return error because of the same name")
+	}
+
+	var result User
+	if err := DB.First(&result, user.ID).Error; err != nil {
+		t.Errorf("Failed, got error: %v", err)
+	}
+}

--- a/tidbcloud.yml
+++ b/tidbcloud.yml
@@ -2,3 +2,4 @@ github:
   branch:
     allowList:
       - "ci_example"
+      - "uk_example"


### PR DESCRIPTION
# How GitHub App works in this example

This example alters `name` column as unique key in the `users` table.

1. The production cluster has two rows with the `jinzhu` name, causing the migration to fail in the test at first. We can find this data problem because the branch copies the whole data.

![image](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/assets/52435083/79473cec-2026-4383-bb4e-ca12d0456b01)


2. After fixing the data problem in the production cluster, we add a test for the new feature and success at last.